### PR TITLE
Clear trade licenses from redux store to avoid documents duplication for subsequent applications

### DIFF
--- a/web/rainmaker/dev-packages/egov-tradelicence-dev/src/ui-config/screens/specs/tradelicence/acknowledgementResource/acknowledgementUtils.js
+++ b/web/rainmaker/dev-packages/egov-tradelicence-dev/src/ui-config/screens/specs/tradelicence/acknowledgementResource/acknowledgementUtils.js
@@ -16,7 +16,7 @@ const style = {
     fontWeight: 400
   },
   tailNumber: {
-    fontSize: 24,
+    fontSize: 15,
     fontWeight: 500
   },
   tailBox: {

--- a/web/rainmaker/dev-packages/egov-tradelicence-dev/src/ui-config/screens/specs/tradelicence/applyResource/footer.js
+++ b/web/rainmaker/dev-packages/egov-tradelicence-dev/src/ui-config/screens/specs/tradelicence/applyResource/footer.js
@@ -801,7 +801,7 @@ export const renewTradelicence  = async (financialYear,state,dispatch) => {
     "LicensesTemp[0].estimateCardData",
     dispatch
 );
-const route = `/tradelicense-citizen/apply?tenantId=${tenantId}`
+const route = `/tradelicense-citizen/apply?applicationNumber=${updateResponse.Licenses[0].applicationNumber}&tenantId=${tenantId}`
   dispatch(setRoute(route));
   dispatch(
     handleField(

--- a/web/rainmaker/dev-packages/egov-tradelicence-dev/src/ui-config/screens/specs/tradelicense-citizen/apply.js
+++ b/web/rainmaker/dev-packages/egov-tradelicence-dev/src/ui-config/screens/specs/tradelicense-citizen/apply.js
@@ -176,6 +176,12 @@ const screenConfig = {
           []
         )
       )
+      dispatch(
+        prepareFinalObject(
+          "LicensesTemp",
+          []
+        )
+      )
     }
     const queryValue = getQueryArg(window.location.href, "applicationNumber") || get(
       state.screenConfiguration.preparedFinalObject,


### PR DESCRIPTION
Reduce the font size of application in acknowledgment screen for mobile devices.